### PR TITLE
Add configurable homepage generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
+# Discover Knowledge Homepage
 
+Generate a simple static `index.html` homepage from a JSON configuration file.
+
+## Configuration
+
+Edit `homepage_config.json` to customize the page. The file supports:
+
+- `title`: text for the `<title>` element.
+- `header`: heading displayed at the top of the page.
+- `footer`: footer text.
+- `sections`: list of sections with `title` and `content` fields.
+
+## Generate the Homepage
+
+Run the generator:
+
+```bash
+python generate_homepage.py
+```
+
+The script creates `index.html` based on the configuration.

--- a/generate_homepage.py
+++ b/generate_homepage.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+def generate_homepage(config_path: str = "homepage_config.json", output_path: str = "index.html") -> None:
+    """Generate a simple HTML homepage from a JSON configuration file.
+
+    The configuration file may define the following keys:
+    - title:     text for the <title> element
+    - header:    heading displayed at the top of the page
+    - footer:    footer text displayed at the bottom of the page
+    - sections:  list of {"title": str, "content": str} dictionaries representing
+                  page sections
+    """
+    config_file = Path(config_path)
+    config = json.loads(config_file.read_text()) if config_file.exists() else {}
+
+    def section_html(section: dict) -> str:
+        title = section.get("title", "")
+        content = section.get("content", "")
+        return f"<section>\n  <h2>{title}</h2>\n  <p>{content}</p>\n</section>"
+
+    sections = config.get("sections", [])
+    sections_html = "\n".join(section_html(s) for s in sections)
+
+    html = f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"UTF-8\" />
+  <title>{config.get('title', '')}</title>
+</head>
+<body>
+  <header>
+    <h1>{config.get('header', '')}</h1>
+  </header>
+  <main>
+{sections_html}
+  </main>
+  <footer>
+    {config.get('footer', '')}
+  </footer>
+</body>
+</html>
+"""
+
+    Path(output_path).write_text(html)
+    print(f"Generated {output_path} from {config_path}")
+
+if __name__ == "__main__":
+    generate_homepage()

--- a/homepage_config.json
+++ b/homepage_config.json
@@ -1,0 +1,9 @@
+{
+  "title": "Discover Knowledge",
+  "header": "Welcome to Discover Knowledge",
+  "footer": "© 2024 Discover Knowledge",
+  "sections": [
+    {"title": "About", "content": "We help you uncover insights and learn new things."},
+    {"title": "Features", "content": "Configurable homepage generated from JSON."}
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Discover Knowledge</title>
+</head>
+<body>
+  <header>
+    <h1>Welcome to Discover Knowledge</h1>
+  </header>
+  <main>
+<section>
+  <h2>About</h2>
+  <p>We help you uncover insights and learn new things.</p>
+</section>
+<section>
+  <h2>Features</h2>
+  <p>Configurable homepage generated from JSON.</p>
+</section>
+  </main>
+  <footer>
+    © 2024 Discover Knowledge
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `generate_homepage.py` to build a homepage from a JSON configuration
- add `homepage_config.json` with sample content and generated `index.html`
- document configuration and usage in README

## Testing
- `python generate_homepage.py`
- `python -m py_compile generate_homepage.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8567583ac832abb78fccd34703009